### PR TITLE
feat: support pdf and docx documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An open-source Retrieval-Augmented Generation (RAG) system for intelligent docum
 ## Features
 
 - **Document Processing**: Automatically process and index documents for intelligent retrieval
+- **Supported Formats**: Markdown (`.md`), PDF (`.pdf`), and Word (`.docx`) files
 - **Semantic Search**: Find relevant information using natural language queries
 - **Chat Interface**: Interactive Q&A based on your document corpus
 - **Validation Framework**: Built-in validation system for custom data types
@@ -84,7 +85,7 @@ The API will be available at `http://localhost:8000`
 
 ### Processing Documents
 
-Place your documents in the `docs/` directory and process them:
+Place your Markdown, PDF, or DOCX documents in the `docs/` directory and process them:
 
 ```bash
 curl -X POST http://localhost:8000/process-docs

--- a/src/core/document_processor.py
+++ b/src/core/document_processor.py
@@ -1,51 +1,77 @@
-from typing import List, Dict
+from typing import List, Dict, Optional
 import os
-from langchain_community.document_loaders import DirectoryLoader
+from datetime import datetime
+
+from langchain_community.document_loaders import (
+    DirectoryLoader,
+    PyPDFLoader,
+    Docx2txtLoader,
+)
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceEmbeddings
 from pinecone import Pinecone
-from datetime import datetime
+
 
 class DocumentProcessor:
     def __init__(self):
         # Initialize Pinecone
-        self.pc = Pinecone(
-            api_key=os.getenv("PINECONE_API_KEY")
-        )
+        self.pc = Pinecone(api_key=os.getenv("PINECONE_API_KEY"))
         self.index_name = os.getenv("PINECONE_INDEX")
         self.index = self.pc.Index(self.index_name)
-        
+
         # Initialize embeddings
-        self.embeddings = HuggingFaceEmbeddings(model_name='all-MiniLM-L6-v2')
-        
+        self.embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+
         # Initialize text splitter
         self.text_splitter = RecursiveCharacterTextSplitter(
-            chunk_size=1000,
-            chunk_overlap=200
+            chunk_size=1000, chunk_overlap=200
         )
 
-    async def process_documents(self, docs_dir: str = "docs") -> List[Dict]:
-        """Process all markdown documents in the docs directory"""
-        # Load documents
-        loader = DirectoryLoader(docs_dir, glob="*.md")
-        documents = loader.load()
-        
+    async def process_documents(
+        self,
+        docs_dir: str = "docs",
+        allowed_file_types: Optional[List[str]] = None,
+    ) -> List[Dict]:
+        """Process documents in the docs directory.
+
+        Args:
+            docs_dir: Directory containing documents.
+            allowed_file_types: List of file extensions to load. Defaults to
+                ["md", "pdf", "docx"].
+        """
+        if allowed_file_types is None:
+            allowed_file_types = ["md", "pdf", "docx"]
+
+        documents = []
+        for file_type in allowed_file_types:
+            glob_pattern = f"*.{file_type}"
+            if file_type == "pdf":
+                loader = DirectoryLoader(
+                    docs_dir, glob=glob_pattern, loader_cls=PyPDFLoader
+                )
+            elif file_type == "docx":
+                loader = DirectoryLoader(
+                    docs_dir, glob=glob_pattern, loader_cls=Docx2txtLoader
+                )
+            else:
+                loader = DirectoryLoader(docs_dir, glob=glob_pattern)
+            documents.extend(loader.load())
+
         # Split documents
         texts = self.text_splitter.split_documents(documents)
-        
+
         # Create embeddings and upload to Pinecone
         for i, text in enumerate(texts):
             embedding = self.embeddings.embed_query(text.page_content)
-            
+
             metadata = {
                 "text": text.page_content,
                 "source": text.metadata.get("source", ""),
-                "created_at": datetime.now().isoformat()
+                "created_at": datetime.now().isoformat(),
             }
-            
+
             # Upload to Pinecone
-            self.index.upsert(
-                vectors=[(f"doc_{i}", embedding, metadata)]
-            )
-        
+            self.index.upsert(vectors=[(f"doc_{i}", embedding, metadata)])
+
         return texts
+


### PR DESCRIPTION
## Summary
- allow DocumentProcessor to process Markdown, PDF, and DOCX files via configurable `allowed_file_types`
- note supported document formats in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6474f82b8832bab8994773a6e44c4