### PR TITLE
Require user ID when storing history

### DIFF
--- a/migrations/versions/6cde8b243f7d_require_user_id.py
+++ b/migrations/versions/6cde8b243f7d_require_user_id.py
@@ -1,0 +1,36 @@
+"""require user id not null
+
+Revision ID: 6cde8b243f7d
+Revises: 9983a1e2e606
+Create Date: 2025-02-14 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "6cde8b243f7d"
+down_revision: Union[str, None] = "9983a1e2e606"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "validation_history", "user_id", existing_type=sa.Integer(), nullable=False
+    )
+    op.alter_column(
+        "chat_history", "user_id", existing_type=sa.Integer(), nullable=False
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "chat_history", "user_id", existing_type=sa.Integer(), nullable=True
+    )
+    op.alter_column(
+        "validation_history", "user_id", existing_type=sa.Integer(), nullable=True
+    )

--- a/src/models/chat.py
+++ b/src/models/chat.py
@@ -1,15 +1,18 @@
 from pydantic import BaseModel
 from datetime import datetime
 
+
 class ChatMessage(BaseModel):
     content: str
     role: str = "user"
     timestamp: datetime = datetime.now()
+    user_id: int
 
     class Config:
         json_schema_extra = {
             "example": {
                 "content": "How can I validate my EIN?",
-                "role": "user"
+                "role": "user",
+                "user_id": 1,
             }
         }

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -4,24 +4,28 @@ from sqlalchemy.orm import relationship
 from datetime import datetime
 from ..utils.database import Base
 
+
 class User(Base):
     """User model for storing user information"""
+
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String, unique=True, index=True)
     created_at = Column(DateTime, default=datetime.utcnow)
-    
+
     # Relationships
     validations = relationship("ValidationHistory", back_populates="user")
     chats = relationship("ChatHistory", back_populates="user")
 
+
 class ValidationHistory(Base):
     """Model for storing validation history"""
+
     __tablename__ = "validation_history"
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"))
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     ein = Column(String)
     duns = Column(String)
     is_valid = Column(Boolean)
@@ -30,12 +34,14 @@ class ValidationHistory(Base):
     # Relationship
     user = relationship("User", back_populates="validations")
 
+
 class ChatHistory(Base):
     """Model for storing chat history"""
+
     __tablename__ = "chat_history"
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"))
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     message = Column(Text)
     response = Column(Text)
     created_at = Column(DateTime, default=datetime.utcnow)


### PR DESCRIPTION
## Summary
- include `user_id` in chat and validation payloads
- record `user_id` on validation and chat history
- make `user_id` columns non-null with migration

## Testing
- `pytest`
- `python -m alembic upgrade head --sql` *(fails: No module named alembic)*

------
https://chatgpt.com/codex/tasks/task_e_68c6474a8ff0832b84a1cc30b4e8390d