### PR TITLE
Remove unnecessary async usage in backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 .env
 *.egg-info/
+frontend/node_modules/

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -50,11 +50,11 @@ Be helpful and provide specific guidance about Omnizon's platform."""
 
 # Endpoints
 @app.get("/")
-async def root():
+def root():
     return {"message": "Welcome to Omnizon RAG API"}
 
 @app.post("/validate")
-async def validate_compliance(
+def validate_compliance(
     request: ValidationRequest,
     db: Session = Depends(get_db)
 ):
@@ -84,13 +84,13 @@ async def validate_compliance(
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.post("/chat")
-async def chat(
+def chat(
     message: ChatMessage,
     db: Session = Depends(get_db)
 ):
     try:
         # Get relevant context from documents
-        context = await retrieval_service.get_relevant_context(message.content)
+        context = retrieval_service.get_relevant_context(message.content)
         
         # Get response from OpenAI with context
         response = client.chat.completions.create(
@@ -122,20 +122,20 @@ async def chat(
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/chat/history")
-async def get_chat_history(db: Session = Depends(get_db)):
+def get_chat_history(db: Session = Depends(get_db)):
     chats = db.query(ChatHistory).order_by(ChatHistory.created_at.desc()).all()
     return chats
 
 @app.get("/validate/history")
-async def get_validation_history(db: Session = Depends(get_db)):
+def get_validation_history(db: Session = Depends(get_db)):
     validations = db.query(ValidationHistory).order_by(ValidationHistory.created_at.desc()).all()
     return validations
 
 @app.post("/process-docs")
-async def process_documents():
+def process_documents():
     try:
         processor = DocumentProcessor()
-        texts = await processor.process_documents()
+        texts = processor.process_documents()
         return {"message": f"Processed {len(texts)} document chunks successfully"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/src/core/document_processor.py
+++ b/src/core/document_processor.py
@@ -24,28 +24,28 @@ class DocumentProcessor:
             chunk_overlap=200
         )
 
-    async def process_documents(self, docs_dir: str = "docs") -> List[Dict]:
+    def process_documents(self, docs_dir: str = "docs") -> List[Dict]:
         """Process all markdown documents in the docs directory"""
         # Load documents
         loader = DirectoryLoader(docs_dir, glob="*.md")
         documents = loader.load()
-        
+
         # Split documents
         texts = self.text_splitter.split_documents(documents)
-        
+
         # Create embeddings and upload to Pinecone
         for i, text in enumerate(texts):
             embedding = self.embeddings.embed_query(text.page_content)
-            
+
             metadata = {
                 "text": text.page_content,
                 "source": text.metadata.get("source", ""),
                 "created_at": datetime.now().isoformat()
             }
-            
+
             # Upload to Pinecone
             self.index.upsert(
                 vectors=[(f"doc_{i}", embedding, metadata)]
             )
-        
+
         return texts

--- a/src/core/validation.py.txt
+++ b/src/core/validation.py.txt
@@ -1,9 +1,9 @@
 # src/core/validation/validation.py
 class ValidationService:
-    async def validate_ein(self, ein: str) -> bool:
+    def validate_ein(self, ein: str) -> bool:
         # Basic validation: 9 digits
         return len(ein.replace('-', '')) == 9 and ein.replace('-', '').isdigit()
 
-    async def validate_duns(self, duns: str) -> bool:
+    def validate_duns(self, duns: str) -> bool:
         # Basic validation: 9 digits
         return len(duns.replace('-', '')) == 9 and duns.replace('-', '').isdigit()

--- a/src/core/validation/validation.py
+++ b/src/core/validation/validation.py
@@ -1,11 +1,11 @@
 class ValidationService:
-    async def validate_ein(self, ein: str) -> bool:
+    def validate_ein(self, ein: str) -> bool:
         if not ein:
             return True
         clean_ein = ein.replace('-', '')
         return len(clean_ein) == 9 and clean_ein.isdigit()
 
-    async def validate_duns(self, duns: str) -> bool:
+    def validate_duns(self, duns: str) -> bool:
         if not duns:
             return True
         clean_duns = duns.replace('-', '')

--- a/src/services/chat_services.py
+++ b/src/services/chat_services.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from ..models.chat import ChatMessage
 
 class ChatService:
-    async def process_message(self, message: ChatMessage):
+    def process_message(self, message: ChatMessage):
         return {
             "content": f"You said: {message.content}",
             "role": "assistant",

--- a/src/services/retrieval_service.py
+++ b/src/services/retrieval_service.py
@@ -13,18 +13,18 @@ class RetrievalService:
         self.index = self.pc.Index(os.getenv("PINECONE_INDEX"))
         self.embeddings = HuggingFaceEmbeddings(model_name='all-MiniLM-L6-v2')
 
-    async def get_relevant_context(self, query: str, top_k: int = 3) -> str:
+    def get_relevant_context(self, query: str, top_k: int = 3) -> str:
         """Get relevant document chunks for a query"""
         # Create query embedding
         query_embedding = self.embeddings.embed_query(query)
-        
+
         # Search Pinecone
         results = self.index.query(
             vector=query_embedding,
             top_k=top_k,
             include_metadata=True
         )
-        
+
         # Extract and combine relevant texts
         contexts = [result.metadata["text"] for result in results.matches]
         return "\n\n".join(contexts)


### PR DESCRIPTION
## Summary
- convert chat, retrieval, document processing and validation services to synchronous functions
- simplify FastAPI endpoints by removing async/await and adjusting calls
- ignore frontend `node_modules` in Git

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c647492c64832b89dcce4057037786