### PR TITLE
Remove deprecated validation service placeholder

### DIFF
--- a/src/core/validation.py.txt
+++ b/src/core/validation.py.txt
@@ -1,9 +1,0 @@
-# src/core/validation/validation.py
-class ValidationService:
-    async def validate_ein(self, ein: str) -> bool:
-        # Basic validation: 9 digits
-        return len(ein.replace('-', '')) == 9 and ein.replace('-', '').isdigit()
-
-    async def validate_duns(self, duns: str) -> bool:
-        # Basic validation: 9 digits
-        return len(duns.replace('-', '')) == 9 and duns.replace('-', '').isdigit()


### PR DESCRIPTION
## Summary
- delete leftover `validation.py.txt` stub
- verify validation service resides in `core/validation/validation.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c647472ce0832bbcdcef3802b93e5e