### PR TITLE
refactor: delegate EIN/DUNS checks to ValidationService

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -11,6 +11,7 @@ from src.models.models import User, ValidationHistory, ChatHistory
 from src.utils.database import get_db
 from src.services.retrieval_service import RetrievalService
 from src.core.document_processor import DocumentProcessor
+from src.core.validation.validation import ValidationService
 
 # Load environment variables and setup
 load_dotenv()
@@ -18,6 +19,7 @@ client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 # Initialize services
 retrieval_service = RetrievalService()
+validation_service = ValidationService()
 
 app = FastAPI(title="Omnizon RAG")
 
@@ -59,9 +61,9 @@ async def validate_compliance(
     db: Session = Depends(get_db)
 ):
     try:
-        # Perform validation
-        ein_valid = len(request.ein.replace('-', '')) == 9 if request.ein else True
-        duns_valid = len(request.duns.replace('-', '')) == 9 if request.duns else True
+        # Perform validation using ValidationService
+        ein_valid = await validation_service.validate_ein(request.ein)
+        duns_valid = await validation_service.validate_duns(request.duns)
         
         # Store validation history
         validation = ValidationHistory(

--- a/tests/test_validation_api.py
+++ b/tests/test_validation_api.py
@@ -1,0 +1,55 @@
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+from fastapi.testclient import TestClient
+from src.api.main import app, validation_service, get_db
+
+
+class DummyDB:
+    def add(self, obj):
+        pass
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+def override_get_db():
+    db = DummyDB()
+    try:
+        yield db
+    finally:
+        pass
+
+
+def test_validate_uses_validation_service(monkeypatch):
+    calls = {"ein": False, "duns": False}
+
+    async def mock_validate_ein(ein):
+        calls["ein"] = True
+        return True
+
+    async def mock_validate_duns(duns):
+        calls["duns"] = True
+        return False
+
+    monkeypatch.setattr(validation_service, "validate_ein", mock_validate_ein)
+    monkeypatch.setattr(validation_service, "validate_duns", mock_validate_duns)
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    client = TestClient(app)
+    response = client.post("/validate", json={"ein": "12-3456789", "duns": "12-345-6789"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "valid": False,
+        "details": {"ein": True, "duns": False},
+    }
+    assert calls["ein"] and calls["duns"]
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- Import and instantiate ValidationService in API
- Replace inline EIN and DUNS validation with ValidationService calls
- Add tests ensuring /validate endpoint relies on ValidationService

## Testing
- `pytest tests/test_validation_api.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68c6474825bc832bb0e492adf4ffbbe4