### PR TITLE
refactor: centralize ChatMessage model

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -8,6 +8,7 @@ import os
 from dotenv import load_dotenv
 from sqlalchemy.orm import Session
 from src.models.models import User, ValidationHistory, ChatHistory
+from src.models.chat import ChatMessage
 from src.utils.database import get_db
 from src.services.retrieval_service import RetrievalService
 from src.core.document_processor import DocumentProcessor
@@ -31,11 +32,6 @@ app.add_middleware(
 )
 
 # Models
-class ChatMessage(BaseModel):
-    content: str
-    role: str = "user"
-    timestamp: datetime = datetime.now()
-
 class ValidationRequest(BaseModel):
     ein: Optional[str] = None
     duns: Optional[str] = None


### PR DESCRIPTION
## Summary
- remove ChatMessage definition from API layer
- import shared ChatMessage model for chat endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c64745f194832ba2a67ff6a16080af