### PR TITLE
Add runtime checks for required env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ pip install -r requirement.txt
 
 3. **Configure environment variables**
 
+The backend requires the following environment variables:
+
+- `OPENAI_API_KEY` – your OpenAI API key used for language model access.
+- `DATABASE_URL` – PostgreSQL connection string for the application database.
+
 Create a `.env` file in the root directory:
 ```env
 # Required

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -14,7 +14,11 @@ from src.core.document_processor import DocumentProcessor
 
 # Load environment variables and setup
 load_dotenv()
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+client = OpenAI(api_key=OPENAI_API_KEY)
 
 # Initialize services
 retrieval_service = RetrievalService()

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -10,6 +10,8 @@ load_dotenv()
 
 # Get database URL from environment variables
 DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL environment variable is not set")
 
 # Create SQLAlchemy engine
 engine = create_engine(DATABASE_URL)


### PR DESCRIPTION
## Summary
- ensure `DATABASE_URL` is set before connecting to database
- validate `OPENAI_API_KEY` on startup
- document required environment variables in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6474b5688832b9e4767d194ed7600